### PR TITLE
feat(API): Plugin status via forwards, fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           cp -R addons/sourcemod/data /tmp/package/common/addons/sourcemod/
 
       - name: Upload build archive for test runners
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ runner.os }}
           path: /tmp/package
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Versioning
         run: |

--- a/addons/sourcemod/scripting/VIP_Core.sp
+++ b/addons/sourcemod/scripting/VIP_Core.sp
@@ -7,7 +7,11 @@
 #include <clientprefs>
 
 #if !defined VIP_VERSION
-#define VIP_VERSION		"3.0.5 R"
+#define VIP_V_MAJOR	"3"
+#define VIP_V_MINOR	"0"
+#define VIP_V_PATCH	"6"
+
+#define VIP_VERSION		"3.0.6 R"
 #endif
 
 
@@ -97,4 +101,15 @@ public void OnPluginStart()
 public void OnAllPluginsLoaded()
 {
 	DB_OnPluginStart();
+	API_OnAllPluginsLoaded();
+}
+
+public void OnPluginPauseChange(bool pause)
+{
+	API_OnPluginPauseChange(pause);
+}
+
+public void OnPluginEnd()
+{
+	API_OnPluginEnd();
 }

--- a/addons/sourcemod/scripting/include/vip_core.inc
+++ b/addons/sourcemod/scripting/include/vip_core.inc
@@ -155,6 +155,21 @@ forward void VIP_OnFeatureRegistered(const char[] szFeature);
 forward void VIP_OnFeatureUnregistered(const char[] szFeature);
 
 /**
+ * Вызывается, когда плагин становится доступным.
+ * 
+ * @noreturn
+ */
+forward void VIPCore_OnPluginOK();
+
+/**
+ * Вызывается, когда плагин становится недоступным.
+ * Это может произойти, когда плагин приостановлен или выгружен.
+ * 
+ * @noreturn
+ */
+forward void VIPCore_OnPluginNotOK();
+
+/**
  *	Вызывается перед проверкой игрока на наличие VIP-статуса.
  *
  * @param iClient			Индекс игрока.

--- a/addons/sourcemod/scripting/vip/API.sp
+++ b/addons/sourcemod/scripting/vip/API.sp
@@ -11,10 +11,14 @@ static Handle g_hGlobalForward_OnFeatureToggle;
 static Handle g_hGlobalForward_OnFeatureRegistered;
 static Handle g_hGlobalForward_OnFeatureUnregistered;
 static Handle g_hGlobalForward_OnClientDisconnect;
+static Handle g_hGlobalForward_StatusOK;
+static Handle g_hGlobalForward_StatusNotOK;
 
 void API_SetupForwards()
 {
 	// Global Forwards
+	g_hGlobalForward_StatusOK = CreateGlobalForward("VIPCore_OnPluginOK", ET_Ignore);
+	g_hGlobalForward_StatusNotOK = CreateGlobalForward("VIPCore_OnPluginNotOK", ET_Ignore);
 	g_hGlobalForward_OnClientPreLoad = CreateGlobalForward("VIP_OnClientPreLoad", ET_Hook, Param_Cell);
 	g_hGlobalForward_OnVIPLoaded = CreateGlobalForward("VIP_OnVIPLoaded", ET_Ignore);
 	g_hGlobalForward_OnClientLoaded = CreateGlobalForward("VIP_OnClientLoaded", ET_Ignore, Param_Cell, Param_Cell);
@@ -29,7 +33,39 @@ void API_SetupForwards()
 	g_hGlobalForward_OnClientDisconnect = CreateGlobalForward("VIP_OnClientDisconnect", ET_Ignore, Param_Cell, Param_Cell);
 }
 
+void API_OnAllPluginsLoaded()
+{
+	CreateForward_OnPluginOK();
+}
+
+void API_OnPluginPauseChange(bool pause)
+{
+	if (pause)
+		CreateForward_OnPluginNotOK();
+	else
+		CreateForward_OnPluginOK();
+}
+
+void API_OnPluginEnd()
+{
+	CreateForward_OnPluginNotOK();
+}
+
 // Global Forwards
+void CreateForward_OnPluginOK()
+{
+	DBG_API("CreateForward_OnPluginOK()")
+	Call_StartForward(g_hGlobalForward_StatusOK);
+	Call_Finish();
+}
+
+void CreateForward_OnPluginNotOK()
+{
+	DBG_API("CreateForward_OnPluginNotOK()")
+	Call_StartForward(g_hGlobalForward_StatusNotOK);
+	Call_Finish();
+}
+
 void CreateForward_OnVIPLoaded()
 {
 	DBG_API("CreateForward_OnVIPLoaded()")


### PR DESCRIPTION
These new forwards prevent the usage of `OnLibraryAdded/Removed` / `OnAllPluginsLoaded + LibraryExists` for external plugins who want to verify if VIP_Core is loaded or not.