### PR TITLE
fix: use Database.Format for SQL escaping instead of manual Escape

### DIFF
--- a/addons/sourcemod/scripting/VIP_Core.sp
+++ b/addons/sourcemod/scripting/VIP_Core.sp
@@ -7,7 +7,7 @@
 #include <clientprefs>
 
 #if !defined VIP_VERSION
-#define VIP_VERSION		"3.1.1 R"
+#define VIP_VERSION		"3.1.2 R"
 #endif
 
 

--- a/addons/sourcemod/scripting/vip/Database.sp
+++ b/addons/sourcemod/scripting/vip/Database.sp
@@ -185,10 +185,9 @@ void DB_UpdateClient(int iClient, const char[] szDbName = NULL_STRING)
 
 	if (g_CVAR_bUpdateName || !strcmp(szDbName, "unknown"))
 	{
-		char szName[MNL*2+1];
-		GetClientName(iClient, szQuery, MNL);
-		g_hDatabase.Escape(szQuery, SZF(szName));
-		FormatEx(SZF(szQuery), "UPDATE `vip_users` SET `name` = '%s', `lastvisit` = %d WHERE `account_id` = %d%s;", szName, GetTime(), iClientID, g_szSID);
+		char szName[MNL];
+		GetClientName(iClient, SZF(szName));
+		g_hDatabase.Format(SZF(szQuery), "UPDATE `vip_users` SET `name` = '%s', `lastvisit` = %d WHERE `account_id` = %d%s;", szName, GetTime(), iClientID, g_szSID);
 	}
 	else
 	{

--- a/addons/sourcemod/scripting/vip/UTIL.sp
+++ b/addons/sourcemod/scripting/vip/UTIL.sp
@@ -280,7 +280,7 @@ void UTIL_ADD_VIP_PLAYER(int iAdmin = 0,
 						const char[] szGroup,
 						const char[] szByWho = NULL_STRING)
 {
-	char szQuery[PMP*2], szName[MNL*2+1];
+	char szQuery[PMP*2], szName[MNL];
 	char szAdmin[PMP], szTargetInfo[PMP];
 	int iExpires, iAccountID;
 
@@ -292,11 +292,10 @@ void UTIL_ADD_VIP_PLAYER(int iAdmin = 0,
 	{
 		iExpires = iDuration;
 	}
-	
+
 	if (iTarget)
 	{
-		GetClientName(iTarget, SZF(szQuery));
-		g_hDatabase.Escape(szQuery, SZF(szName));
+		GetClientName(iTarget, SZF(szName));
 		iAccountID = GetSteamAccountID(iTarget);
 		UTIL_GetClientInfo(iTarget, SZF(szTargetInfo));
 	}
@@ -353,7 +352,7 @@ void UTIL_ADD_VIP_PLAYER(int iAdmin = 0,
 	
 	if (GLOBAL_INFO & IS_MySQL)
 	{
-		FormatEx(SZF(szQuery), "INSERT INTO `vip_users` (`account_id`, `sid`, `expires`, `group`, `name`, `lastvisit`) VALUES (%d, %d, %d, '%s', '%s', %d) \
+		g_hDatabase.Format(SZF(szQuery), "INSERT INTO `vip_users` (`account_id`, `sid`, `expires`, `group`, `name`, `lastvisit`) VALUES (%d, %d, %d, '%s', '%s', %d) \
 		ON DUPLICATE KEY UPDATE `group` = VALUES(`group`), `expires` = IF(`expires` = 0, 0, IF(`expires` <= UNIX_TIMESTAMP(), VALUES(`expires`), `expires` + %d));",
 		iAccountID, g_CVAR_iServerID, iExpires, szGroup, szName, iLastVisit, iDuration);
 		DBG_SQL_Query(szQuery)
@@ -362,7 +361,7 @@ void UTIL_ADD_VIP_PLAYER(int iAdmin = 0,
 		return;
 	}
 
-	FormatEx(SZF(szQuery), "INSERT INTO `vip_users` (`account_id`, `name`, `expires`, `group`, `lastvisit`) VALUES (%d, '%s', %d, '%s', %d) \
+	g_hDatabase.Format(SZF(szQuery), "INSERT INTO `vip_users` (`account_id`, `name`, `expires`, `group`, `lastvisit`) VALUES (%d, '%s', %d, '%s', %d) \
 	ON CONFLICT (`account_id`) DO UPDATE SET \
 	`group` = excluded.`group` \
 	`expires` = CASE \
@@ -382,7 +381,7 @@ void UTIL_SET_VIP_PLAYER(int iAdmin = 0,
 						const char[] szGroup,
 						const char[] szByWho = NULL_STRING)
 {
-	char szQuery[PMP*2], szName[MNL*2+1];
+	char szQuery[PMP*2], szName[MNL];
 	char szAdmin[PMP], szTargetInfo[PMP];
 	int iExpires, iAccountID;
 
@@ -394,11 +393,10 @@ void UTIL_SET_VIP_PLAYER(int iAdmin = 0,
 	{
 		iExpires = iDuration;
 	}
-	
+
 	if (iTarget)
 	{
-		GetClientName(iTarget, SZF(szQuery));
-		g_hDatabase.Escape(szQuery, SZF(szName));
+		GetClientName(iTarget, SZF(szName));
 		iAccountID = GetSteamAccountID(iTarget);
 		UTIL_GetClientInfo(iTarget, SZF(szTargetInfo));
 	}


### PR DESCRIPTION
## Summary
- Replace manual `g_hDatabase.Escape` + separate escaped buffers with `g_hDatabase.Format`, which escapes `%s` string arguments directly against the query, in `Database.sp` and `UTIL.sp`.
- Bump version (3.1.1 R -> 3.1.2 R).

## Why
`Database.Format` is cleaner than a manual escape-then-format call per parameter and avoids extra driver/threading touchpoints from calling Escape directly.

## Notes
- `UTIL_SET_VIP_PLAYER`'s locally-computed `szName` was already unused after being escaped (never written into the `DataPack`, so `SQL_UpdateVIP` never reads it back) — that's a pre-existing bug unrelated to escaping and left untouched here; this PR only removes the now-unnecessary manual escape call in that function.

## Test plan
- [ ] Compile plugin and confirm no errors
- [ ] Add/update a VIP with a client name containing quotes and confirm the query still succeeds